### PR TITLE
Fix conversion of url str to pk

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -444,8 +444,7 @@ def url_str_to_user_pk(s):
     if issubclass(type(pk_field), models.UUIDField):
         return pk_field.to_python(s)
     try:
-        pk_field.to_python('a')
-        pk = s
+        pk = pk_field.to_python(s)
     except ValidationError:
         pk = base36_to_int(s)
     return pk


### PR DESCRIPTION
@mands - Looks like the original author used `pk_field.to_python('a')` to check if the field is of string type since `base36` doesn't have small letters. If this doesn't raise an error it would set `pk = s` in the next statement else it would catch `ValidationError` and convert url string to an integer. This is not always correct way to do it because if the pk field is of different type the validation error would still occur and it would try to convert url string into integer which may not be possible/correct.

I changed:
```python
pk_field.to_python('a')
pk = s
```
to
```python
pk = pk_field.to_python(s)
```
So if the field has to_python method it would first make use of it otherwise fallback to base36 value conversion if error occurs.
This would make it possible to use password reset with third party apps used for `id` like https://github.com/nshafer/django-hashid-field 

